### PR TITLE
HL-18283 Update Readme to indicate commercial subscription is required

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -32,9 +32,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.2'
-            moodle-branch: 'MOODLE_401_STABLE'
-            database: 'pgsql'
           - php: '8.1'
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Grunt
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt --max-lint-warnings 0 || [ "$MOODLE_BRANCH" = 'MOODLE_401_STABLE' ]
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 || [ "$MOODLE_BRANCH" = 'MOODLE_400_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_401_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_402_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_403_STABLE' ]
         env:
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
 

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -32,10 +32,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.2'
+          - php: '8.0'
             moodle-branch: 'MOODLE_403_STABLE'
             database: 'pgsql'
-          - php: '8.1'
+          - php: '8.0'
             moodle-branch: 'MOODLE_402_STABLE'
             database: 'pgsql'
           - php: '8.0'

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -32,11 +32,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '7.4'
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: 'pgsql'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'pgsql'
+          - php: '8.0'
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
-          - php: '7.3'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
             moodle-branch: 'MOODLE_311_STABLE'
+            database: 'pgsql'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_310_STABLE'
+            database: 'pgsql'
+          - php: '7.3'
+            moodle-branch: 'MOODLE_39_STABLE'
             database: 'pgsql'
     steps:
       - name: Check out repository code

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -32,19 +32,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.0'
-            moodle-branch: 'MOODLE_403_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_402_STABLE'
-            database: 'pgsql'
-          - php: '8.0'
+          - php: '8.2'
             moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
-          - php: '8.0'
-            moodle-branch: 'MOODLE_400_STABLE'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
             database: 'pgsql'
           - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: 'pgsql'
+          - php: '7.4'
+            moodle-branch: 'MOODLE_400_STABLE'
+            database: 'pgsql'
+          - php: '7.3'
             moodle-branch: 'MOODLE_311_STABLE'
             database: 'pgsql'
           - php: '7.3'
@@ -120,7 +120,7 @@ jobs:
 
       - name: Grunt
         if: ${{ always() }}
-        run: moodle-plugin-ci grunt --max-lint-warnings 0 || [ "$MOODLE_BRANCH" = 'MOODLE_400_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_401_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_402_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_403_STABLE' ]
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 || [ "$MOODLE_BRANCH" = 'MOODLE_400_STABLE' ] || [ "$MOODLE_BRANCH" = 'MOODLE_401_STABLE' ]
         env:
           MOODLE_BRANCH: ${{ matrix.moodle-branch }}
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the Moodle plugin for integrating with the Honorlock Proctoring! This
 
 The Honorlock Proctoring Moodle plugin is easy to install and use, and requires minimal configuration. It provides a comprehensive solution for proctoring online exams, and is designed to be flexible and adaptable to the specific needs of each institution.
 
-A commercial license with Honorlock is required for integration.
+A commercial license with Honorlock is required for integration. Please reach out to Honorlock for more information [here](https://www.honorlock.com).
 
 In this readme file, we will go through the key features of the Honorlock Proctoring Moodle plugin, and provide detailed instructions on how to install, configure and use it. This readme file will provide all the information you need to get started with the Honorlock Proctoring Moodle plugin.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Welcome to the Moodle plugin for integrating with the Honorlock Proctoring! This plugin provides seamless integration between Moodle and Honorlock Proctoring, enabling online assessments to be proctored and monitored in real time. With this plugin, Moodle administrators can ensure the authenticity and validity of online exams, enhancing the reliability and trustworthiness of online education. 
 
-A commercial subscription to Honorlock is required for the integration. 
-
 The Honorlock Proctoring Moodle plugin is easy to install and use, and requires minimal configuration. It provides a comprehensive solution for proctoring online exams, and is designed to be flexible and adaptable to the specific needs of each institution.
+
+A commercial license with Honorlock is required for integration.
 
 In this readme file, we will go through the key features of the Honorlock Proctoring Moodle plugin, and provide detailed instructions on how to install, configure and use it. This readme file will provide all the information you need to get started with the Honorlock Proctoring Moodle plugin.
 
@@ -24,7 +24,7 @@ In this readme file, we will go through the key features of the Honorlock Procto
 # Requirements
 
 1. Honorlock Proctoring was tested with Moodle 3 and Moodle 4.
-2. An Honorlock organization client id and client secret are required for setup.
+2. Honorlock organization client id and client secret are required for setup
 3. Honorlock Proctoring authenticates for instructors via LTI. Please, check the LTI configuration below.
 
 # Configuration
@@ -50,6 +50,7 @@ The LTI (Learning Tools Interoperability) will serve as the interface for instru
     - Redirection URI(s): https://app.honorlock.com/org/[organization_uuid]/launch
     - Tool configuration usage: Show as preconfigured tool when adding an external tool
     - Default launch container: Embed, without blocks
+    - In Moodle 4.3, you will also need to expand the Privacy Settings and Change the dropdown options to Always Share launchers name with tool and Always Share launchers email with tool
     - ***[optional]*** Icon URL (*You might need to click "**Show more...**"*): https://app.honorlock.com/favicons/favicon.ico
 - Scroll down and click the **Save changes** button.
 - On the generated tool box click the configuration details button (<img src="https://raw.githubusercontent.com/FortAwesome/Font-Awesome/6.x/svgs/solid/list.svg" width="12" height="12">) and take note of the following values as they will need to be provided to Honorlock to complete setup. 
@@ -72,6 +73,7 @@ The LTI (Learning Tools Interoperability) will serve as the interface for instru
         - Click **Save and return to course**
         - Untoggle **Edit mode**
     - Click the Honorlock LTI external Tool
+- Note for Moodle 4.3, you will need toggle the Show in activity chooser for the LTI in the Course Menu (Select the LTI External Tools option from the “More” dropdown)
 
 ## Plugin Configuration
 The Honorlock Plugin will enable students to take Honorlock proctored exams. To accomplish this, the following steps are required:
@@ -113,12 +115,12 @@ The Honorlock Plugin will enable students to take Honorlock proctored exams. To 
 - Click the Save Changes Button.
 
 #### Enable Web Service REST Protocol
-- Go to Site administration > Server > Web Services > Manage Protocols ([moodleURL]/admin/settings.php?section=webserviceprotocols).
+- Go to Site administration > Server > Web Services > Manage Protocols (In Moodle 3.9 and Above this can be found in Site Adminstration > Plugins > Web Services > Manage Protocols)
 - Click the icon to Enable the REST protocol.
 - Click the Save Changes Button.
 
 #### Create the new web service in Moodle
-- Go to Site administration > Server > Web services > External services.
+- Go to Site administration > Server > Web services > External services (In Moodle 3.9 and Above this can be found in Site Adminstration > Plugins > Web Services > External services)
 - Click Add.
 - Fill in the required fields.
     - Name: Moodle API
@@ -135,7 +137,7 @@ The Honorlock Plugin will enable students to take Honorlock proctored exams. To 
 - Click Add functions.
 
 #### Authorize the created user on the newly created web service
-- Go to Site administration > Server > Web services > External services.
+- Go to Site administration > Server > Web services > External services. (In Moodle 3.9 and Above this can be found in Site Adminstration > Plugins > Web Services > External services)
 - Look for the Moodle API you just created and click the Authorised users link.
 - Add the Honorlock API user to the list of authorized users.
 - Click the user from the Not authorized users list.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Honorlock Proctoring
 
-Welcome to the Moodle plugin for integrating with the Honorlock Proctoring! This plugin provides seamless integration between Moodle and Honorlock Proctoring, enabling online assessments to be proctored and monitored in real time. With this plugin, Moodle administrators can ensure the authenticity and validity of online exams, enhancing the reliability and trustworthiness of online education.
+Welcome to the Moodle plugin for integrating with the Honorlock Proctoring! This plugin provides seamless integration between Moodle and Honorlock Proctoring, enabling online assessments to be proctored and monitored in real time. With this plugin, Moodle administrators can ensure the authenticity and validity of online exams, enhancing the reliability and trustworthiness of online education. 
+
+A commercial subscription to Honorlock is required for the integration. 
 
 The Honorlock Proctoring Moodle plugin is easy to install and use, and requires minimal configuration. It provides a comprehensive solution for proctoring online exams, and is designed to be flexible and adaptable to the specific needs of each institution.
 

--- a/classes/external/get_quiz_questions.php
+++ b/classes/external/get_quiz_questions.php
@@ -79,6 +79,7 @@ class get_quiz_questions extends \external_api {
      */
     public static function execute(int $quizid): array {
         global $DB, $CFG;
+        require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
         require_once($CFG->dirroot . '/question/engine/bank.php');
         $params = self::validate_parameters(self::execute_parameters(), ['quizid' => $quizid]);
         try {
@@ -92,7 +93,7 @@ class get_quiz_questions extends \external_api {
 
             $result = [];
             // Fetch the questions based on the IDs.
-            $quizobj = new \mod_quiz\quiz_settings($quiz, $cm, $quiz->course);
+            $quizobj = new \quiz($quiz, $cm, $quiz->course);
             $quizobj->preload_questions();
             $quizobj->load_questions();
 

--- a/classes/external/get_quiz_questions.php
+++ b/classes/external/get_quiz_questions.php
@@ -79,7 +79,7 @@ class get_quiz_questions extends \external_api {
      */
     public static function execute(int $quizid): array {
         global $DB, $CFG;
-        require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
+       // require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
         require_once($CFG->dirroot . '/question/engine/bank.php');
         $params = self::validate_parameters(self::execute_parameters(), ['quizid' => $quizid]);
         try {
@@ -93,7 +93,7 @@ class get_quiz_questions extends \external_api {
 
             $result = [];
             // Fetch the questions based on the IDs.
-            $quizobj = new \quiz($quiz, $cm, $quiz->course);
+            $quizobj = new \mod_quiz\quiz_settings($quiz, $cm, $quiz->course);
             $quizobj->preload_questions();
             $quizobj->load_questions();
 

--- a/classes/external/get_quiz_questions.php
+++ b/classes/external/get_quiz_questions.php
@@ -79,7 +79,6 @@ class get_quiz_questions extends \external_api {
      */
     public static function execute(int $quizid): array {
         global $DB, $CFG;
-       // require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
         require_once($CFG->dirroot . '/question/engine/bank.php');
         $params = self::validate_parameters(self::execute_parameters(), ['quizid' => $quizid]);
         try {

--- a/classes/external/get_quiz_questions.php
+++ b/classes/external/get_quiz_questions.php
@@ -44,9 +44,9 @@ class get_quiz_questions extends \external_api {
      */
     public static function execute_parameters(): external_function_parameters {
         return new external_function_parameters(
-            array(
+            [
                 'quizid' => new external_value(PARAM_INT, 'Quiz Id', VALUE_REQUIRED),
-            )
+            ]
         );
     }
 
@@ -57,7 +57,7 @@ class get_quiz_questions extends \external_api {
      */
     public static function execute_returns(): external_single_structure {
         return new external_single_structure(
-            array(
+            [
                 'success' => new external_value(PARAM_BOOL, 'Was operation successful? '),
                 'quizid' => new external_value(PARAM_INT, 'Quiz id modified'),
                 'questions' => new external_multiple_structure(
@@ -67,7 +67,7 @@ class get_quiz_questions extends \external_api {
                         'intro' => new external_value(PARAM_RAW, 'Question Text'),
                     ])
                 ),
-            ),
+            ],
         );
     }
 

--- a/classes/honorlockapi.php
+++ b/classes/honorlockapi.php
@@ -119,10 +119,12 @@ class honorlockapi {
     public function send_request(string $type, string $endpoint, array $payload = []): ?object {
         $token = $this->get_token();
         $curl = new \curl();
-        $curl->setHeader(array(
-            'Accept: application/json',
-            "Authorization: Bearer $token",
-        ));
+        $curl->setHeader(
+            [
+                'Accept: application/json',
+                "Authorization: Bearer $token",
+            ]
+        );
 
         $jsonresult = null;
 

--- a/db/caches.php
+++ b/db/caches.php
@@ -24,10 +24,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$definitions = array(
-    'honorlock_api_token' => array(
+$definitions = [
+    'honorlock_api_token' => [
         'mode' => cache_store::MODE_APPLICATION,
         'simplekeys' => true,
         'staticacceleration' => false,
-    ),
-);
+    ],
+];

--- a/lib.php
+++ b/lib.php
@@ -35,7 +35,7 @@ const HL_NO_EDIT = 'HL_NO_EDIT';
  * @param global_navigation $navigation
  * @return void
  */
-function local_honorlockproctoring_extend_navigation(global_navigation $navigation) {
+function local_honorlockproctoring_extend_navigation(global_navigation $navigation): void {
     global $PAGE;
     global $CFG;
     global $USER;
@@ -43,7 +43,7 @@ function local_honorlockproctoring_extend_navigation(global_navigation $navigati
 
     if ($PAGE->cm && $PAGE->cm->modname === 'quiz') {
         $quizid = $PAGE->cm->instance;
-        $quiz = $DB->get_record('quiz', array('id' => $quizid));
+        $quiz = $DB->get_record('quiz', ['id' => $quizid]);
         $attempts = $DB->get_records('quiz_attempts', [
             'quiz' => $quizid,
             'userid' => $USER->id

--- a/tests/external/get_quiz_questions_test.php
+++ b/tests/external/get_quiz_questions_test.php
@@ -33,8 +33,8 @@ use local_honorlockproctoring\external\get_quiz_questions;
  */
 
  /**
- * @runTestsInSeparateProcesses
- */
+  * @runTestsInSeparateProcesses
+  */
 class get_quiz_questions_test extends \externallib_advanced_testcase {
 
     /**

--- a/tests/external/get_quiz_questions_test.php
+++ b/tests/external/get_quiz_questions_test.php
@@ -31,18 +31,17 @@ use local_honorlockproctoring\external\get_quiz_questions;
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+ /**
+ * @runTestsInSeparateProcesses
+ */
 class get_quiz_questions_test extends \externallib_advanced_testcase {
-    /**
-     * @var get_quiz_questions Keeps the get_quiz_questions Class.
-     */
-    protected $getquizquestions;
 
     /**
      * Setup test data.
      */
     protected function setUp(): void {
         $this->resetAfterTest();
-        $this->get_quiz_questions = new get_quiz_questions();
     }
 
     /**
@@ -62,7 +61,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_parameters
      */
     public function test_get_quiz_questions_parameters() {
-        $result = $this->get_quiz_questions->execute_parameters();
+        $result = get_quiz_questions::execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -73,7 +72,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_returns
      */
     public function test_get_quiz_questions_returns() {
-        $result = $this->get_quiz_questions->execute_returns();
+        $result = get_quiz_questions::execute_returns();
 
         $this->assertIsObject($result);
     }
@@ -92,7 +91,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
         quiz_add_quiz_question($question->id, $quiz);
 
         $this->setAdminUser();
-        $result = $this->get_quiz_questions->execute($quiz->id);
+        $result = get_quiz_questions::execute($quiz->id);
 
         $this->assertIsArray($result);
         $this->assertTrue($result['success']);
@@ -111,7 +110,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
             'questions' => [],
         ];
 
-        $result = $this->get_quiz_questions->execute($nonexistentquizid);
+        $result = get_quiz_questions::execute($nonexistentquizid);
 
         $this->assertSame($expected, $result);
     }

--- a/tests/external/get_quiz_questions_test.php
+++ b/tests/external/get_quiz_questions_test.php
@@ -50,7 +50,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\get_quiz_questions
      */
-    public function test_class_creation() {
+    public function test_class_creation(): void {
         $getquizquestions = new get_quiz_questions();
 
         $this->assertInstanceOf(get_quiz_questions::class, $getquizquestions);
@@ -61,7 +61,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_parameters
      */
-    public function test_get_quiz_questions_parameters() {
+    public function test_get_quiz_questions_parameters(): void {
         $result = $this->get_quiz_questions->execute_parameters();
 
         $this->assertIsObject($result);
@@ -72,7 +72,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_returns
      */
-    public function test_get_quiz_questions_returns() {
+    public function test_get_quiz_questions_returns(): void {
         $result = $this->get_quiz_questions->execute_returns();
 
         $this->assertIsObject($result);
@@ -83,12 +83,12 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute
      */
-    public function test_get_quiz_questions() {
+    public function test_get_quiz_questions(): void {
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
         $cat = $questiongenerator->create_question_category();
-        $question = $questiongenerator->create_question('shortanswer', null, array('category' => $cat->id));
+        $question = $questiongenerator->create_question('shortanswer', null, ['category' => $cat->id]);
         quiz_add_quiz_question($question->id, $quiz);
 
         $this->setAdminUser();
@@ -103,7 +103,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute
      */
-    public function test_get_quiz_questions_returns_false() {
+    public function test_get_quiz_questions_returns_false(): void {
         $nonexistentquizid = random_int(1, 5000);
         $expected = [
             'success' => false,

--- a/tests/external/get_quiz_questions_test.php
+++ b/tests/external/get_quiz_questions_test.php
@@ -30,11 +30,8 @@ use local_honorlockproctoring\external\get_quiz_questions;
  * @package   local_honorlockproctoring
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @runTestsInSeparateProcesses
  */
-
- /**
-  * @runTestsInSeparateProcesses
-  */
 class get_quiz_questions_test extends \externallib_advanced_testcase {
 
     /**

--- a/tests/external/get_quiz_questions_test.php
+++ b/tests/external/get_quiz_questions_test.php
@@ -30,15 +30,19 @@ use local_honorlockproctoring\external\get_quiz_questions;
  * @package   local_honorlockproctoring
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @runTestsInSeparateProcesses
  */
 class get_quiz_questions_test extends \externallib_advanced_testcase {
+    /**
+     * @var get_quiz_questions Keeps the get_quiz_questions Class.
+     */
+    protected $getquizquestions;
 
     /**
      * Setup test data.
      */
     protected function setUp(): void {
         $this->resetAfterTest();
+        $this->get_quiz_questions = new get_quiz_questions();
     }
 
     /**
@@ -58,7 +62,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_parameters
      */
     public function test_get_quiz_questions_parameters() {
-        $result = get_quiz_questions::execute_parameters();
+        $result = $this->get_quiz_questions->execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -69,7 +73,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\get_quiz_questions::execute_returns
      */
     public function test_get_quiz_questions_returns() {
-        $result = get_quiz_questions::execute_returns();
+        $result = $this->get_quiz_questions->execute_returns();
 
         $this->assertIsObject($result);
     }
@@ -88,7 +92,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
         quiz_add_quiz_question($question->id, $quiz);
 
         $this->setAdminUser();
-        $result = get_quiz_questions::execute($quiz->id);
+        $result = $this->get_quiz_questions->execute($quiz->id);
 
         $this->assertIsArray($result);
         $this->assertTrue($result['success']);
@@ -107,7 +111,7 @@ class get_quiz_questions_test extends \externallib_advanced_testcase {
             'questions' => [],
         ];
 
-        $result = get_quiz_questions::execute($nonexistentquizid);
+        $result = $this->get_quiz_questions->execute($nonexistentquizid);
 
         $this->assertSame($expected, $result);
     }

--- a/tests/external/update_quiz_test.php
+++ b/tests/external/update_quiz_test.php
@@ -50,7 +50,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz
      */
-    public function test_class_creation() {
+    public function test_class_creation(): void {
         $updatequiz = new update_quiz();
 
         $this->assertInstanceOf(update_quiz::class, $updatequiz);
@@ -61,7 +61,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
-    public function test_update_quiz_values_parameters() {
+    public function test_update_quiz_values_parameters(): void {
         $result = $this->update_quiz->execute_parameters();
 
         $this->assertIsObject($result);
@@ -72,7 +72,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
-    public function test_update_quiz_values_returns() {
+    public function test_update_quiz_values_returns(): void {
         $result = $this->update_quiz->execute_returns();
 
         $this->assertIsObject($result);
@@ -83,9 +83,9 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute
      */
-    public function test_update_quiz_values() {
+    public function test_update_quiz_values(): void {
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
         $this->setAdminUser();
 
         $result = $this->update_quiz->execute($quiz->id, ['password' => 'password']);
@@ -99,7 +99,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute
      */
-    public function test_update_quiz_values_returns_false() {
+    public function test_update_quiz_values_returns_false(): void {
         $this->setAdminUser();
 
         $nonexistentquizid = random_int(1, 5000);
@@ -115,9 +115,9 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute
      */
-    public function test_update_quiz_values_when_value_not_in_allowedquizupdates() {
+    public function test_update_quiz_values_when_value_not_in_allowedquizupdates(): void {
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
         $this->setAdminUser();
 
         $result = $this->update_quiz->execute($quiz->id, ['notpassword' => 'password']);
@@ -131,7 +131,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
-    public function test_get_quiz_questions_parameters() {
+    public function test_get_quiz_questions_parameters(): void {
         $result = $this->update_quiz->execute_parameters();
 
         $this->assertIsObject($result);
@@ -142,7 +142,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      *
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
-    public function test_get_quiz_questions_returns() {
+    public function test_get_quiz_questions_returns(): void {
         $result = $this->update_quiz->execute_returns();
 
         $this->assertIsObject($result);

--- a/tests/external/update_quiz_test.php
+++ b/tests/external/update_quiz_test.php
@@ -30,15 +30,19 @@ use local_honorlockproctoring\external\update_quiz;
  * @package   local_honorlockproctoring
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- * @runTestsInSeparateProcesses
  */
 class update_quiz_test extends \externallib_advanced_testcase {
+    /**
+     * @var update_quiz Keeps the update_quiz Class.
+     */
+    protected $updatequiz;
 
     /**
      * Setup test data.
      */
     protected function setUp(): void {
         $this->resetAfterTest();
+        $this->update_quiz = new update_quiz();
     }
 
     /**
@@ -58,7 +62,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
     public function test_update_quiz_values_parameters() {
-        $result = update_quiz::execute_parameters();
+        $result = $this->update_quiz->execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -69,7 +73,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
     public function test_update_quiz_values_returns() {
-        $result = update_quiz::execute_returns();
+        $result = $this->update_quiz->execute_returns();
 
         $this->assertIsObject($result);
     }
@@ -84,7 +88,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
         $this->setAdminUser();
 
-        $result = update_quiz::execute($quiz->id, ['password' => 'password']);
+        $result = $this->update_quiz->execute($quiz->id, ['password' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertTrue($result['updatedvalues']['password']);
@@ -100,7 +104,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
 
         $nonexistentquizid = random_int(1, 5000);
 
-        $result = update_quiz::execute($nonexistentquizid, ['password' => 'password']);
+        $result = $this->update_quiz->execute($nonexistentquizid, ['password' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertFalse($result['success']);
@@ -116,7 +120,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
         $this->setAdminUser();
 
-        $result = update_quiz::execute($quiz->id, ['notpassword' => 'password']);
+        $result = $this->update_quiz->execute($quiz->id, ['notpassword' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertFalse($result['updatedvalues']['notpassword']);
@@ -128,7 +132,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
     public function test_get_quiz_questions_parameters() {
-        $result = update_quiz::execute_parameters();
+        $result = $this->update_quiz->execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -139,7 +143,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
     public function test_get_quiz_questions_returns() {
-        $result = update_quiz::execute_returns();
+        $result = $this->update_quiz->execute_returns();
 
         $this->assertIsObject($result);
     }

--- a/tests/external/update_quiz_test.php
+++ b/tests/external/update_quiz_test.php
@@ -31,18 +31,17 @@ use local_honorlockproctoring\external\update_quiz;
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+/**
+ * @runTestsInSeparateProcesses
+ */
 class update_quiz_test extends \externallib_advanced_testcase {
-    /**
-     * @var update_quiz Keeps the update_quiz Class.
-     */
-    protected $updatequiz;
 
     /**
      * Setup test data.
      */
     protected function setUp(): void {
         $this->resetAfterTest();
-        $this->update_quiz = new update_quiz();
     }
 
     /**
@@ -62,7 +61,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
     public function test_update_quiz_values_parameters() {
-        $result = $this->update_quiz->execute_parameters();
+        $result = update_quiz::execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -73,7 +72,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
     public function test_update_quiz_values_returns() {
-        $result = $this->update_quiz->execute_returns();
+        $result = update_quiz::execute_returns();
 
         $this->assertIsObject($result);
     }
@@ -88,7 +87,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
         $this->setAdminUser();
 
-        $result = $this->update_quiz->execute($quiz->id, ['password' => 'password']);
+        $result = update_quiz::execute($quiz->id, ['password' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertTrue($result['updatedvalues']['password']);
@@ -104,7 +103,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
 
         $nonexistentquizid = random_int(1, 5000);
 
-        $result = $this->update_quiz->execute($nonexistentquizid, ['password' => 'password']);
+        $result = update_quiz::execute($nonexistentquizid, ['password' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertFalse($result['success']);
@@ -120,7 +119,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
         $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
         $this->setAdminUser();
 
-        $result = $this->update_quiz->execute($quiz->id, ['notpassword' => 'password']);
+        $result = update_quiz::execute($quiz->id, ['notpassword' => 'password']);
 
         $this->assertIsArray($result);
         $this->assertFalse($result['updatedvalues']['notpassword']);
@@ -132,7 +131,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_parameters
      */
     public function test_get_quiz_questions_parameters() {
-        $result = $this->update_quiz->execute_parameters();
+        $result = update_quiz::execute_parameters();
 
         $this->assertIsObject($result);
     }
@@ -143,7 +142,7 @@ class update_quiz_test extends \externallib_advanced_testcase {
      * @covers \local_honorlockproctoring\external\update_quiz::execute_returns
      */
     public function test_get_quiz_questions_returns() {
-        $result = $this->update_quiz->execute_returns();
+        $result = update_quiz::execute_returns();
 
         $this->assertIsObject($result);
     }

--- a/tests/external/update_quiz_test.php
+++ b/tests/external/update_quiz_test.php
@@ -30,9 +30,6 @@ use local_honorlockproctoring\external\update_quiz;
  * @package   local_honorlockproctoring
  * @copyright 2023 Honorlock (https://honorlock.com/)
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
-
-/**
  * @runTestsInSeparateProcesses
  */
 class update_quiz_test extends \externallib_advanced_testcase {

--- a/tests/honorlock_test.php
+++ b/tests/honorlock_test.php
@@ -65,7 +65,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock
      */
-    public function test_class_creation() {
+    public function test_class_creation(): void {
         $honorlock = new honorlock();
 
         $this->assertInstanceOf(honorlock::class, $honorlock);
@@ -76,7 +76,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock::extension_check
      */
-    public function test_extension_check() {
+    public function test_extension_check(): void {
         $testresponse = (object)[
         "data" => [
         "iframe_src" => "https://app.honorlock.com/install/extension?locale=en",
@@ -96,7 +96,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock::create_session
      */
-    public function test_create_session() {
+    public function test_create_session(): void {
         $testresponse = (object)[
         "data" => [
           "session" => [],
@@ -117,7 +117,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock::get_exam_instructions
      */
-    public function test_get_exam_instructions() {
+    public function test_get_exam_instructions(): void {
         $testresponse = (object)[
         "data" => [
           "launch_screen_url" => "https://app.honorlock.com/install/extension?locale=en",
@@ -135,7 +135,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock::begin_session
      */
-    public function test_begin_session() {
+    public function test_begin_session(): void {
         $testresponse = (object)[
         "message" => "Session has already started",
         "data" => [
@@ -160,7 +160,7 @@ class honorlock_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlock::end_session
      */
-    public function test_end_session() {
+    public function test_end_session(): void {
         $testresponse = (object)[
         "data" => [
           "event_type" => "string",

--- a/tests/honorlockapi_test.php
+++ b/tests/honorlockapi_test.php
@@ -48,7 +48,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi
      */
-    public function test_class_creation() {
+    public function test_class_creation(): void {
         $honorlockapi = new honorlockapi();
         $reflection = new \ReflectionClass(get_class($honorlockapi));
         $property = $reflection->getProperty('config');
@@ -65,7 +65,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::send_request
      */
-    public function test_send_get_request() {
+    public function test_send_get_request(): void {
         $this->generate_token();
 
         $testresponse = (object)[
@@ -119,7 +119,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::send_request
      */
-    public function test_send_bad_method_to_send_request_returns_null() {
+    public function test_send_bad_method_to_send_request_returns_null(): void {
         $this->generate_token();
 
         $reflection = new \ReflectionClass(get_class($this->honorlockapi));
@@ -136,7 +136,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::get_token
      */
-    public function test_get_token() {
+    public function test_get_token(): void {
         $this->generate_token();
 
         $reflection = new \ReflectionClass(get_class($this->honorlockapi));
@@ -152,7 +152,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::get_token
      */
-    public function test_get_token_returns_early_with_no_token() {
+    public function test_get_token_returns_early_with_no_token(): void {
 
         $reflection = new \ReflectionClass(get_class($this->honorlockapi));
         $method = $reflection->getMethod('get_token');
@@ -174,7 +174,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::generate_token
      */
-    public function test_generate_token() {
+    public function test_generate_token(): void {
         $reflection = new \ReflectionClass(get_class($this->honorlockapi));
         $method = $reflection->getMethod('generate_token');
         $method->setAccessible(true);
@@ -201,7 +201,7 @@ class honorlockapi_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\honorlockapi::generate_token
      */
-    public function test_generate_token_returns_early_with_no_token() {
+    public function test_generate_token_returns_early_with_no_token(): void {
         $reflection = new \ReflectionClass(get_class($this->honorlockapi));
         $method = $reflection->getMethod('generate_token');
         $method->setAccessible(true);

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -166,7 +166,7 @@ class lib_test extends \advanced_testcase {
 
         \curl::mock_response(json_encode($testresponse));
 
-        $attemptobj = \quiz_attempt::create($attempt->id);
+        $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
         $attemptobj->process_finish(time(), false);
 
         $PAGE = new moodle_page();
@@ -240,7 +240,7 @@ class lib_test extends \advanced_testcase {
         $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
         $this->quiz = $quizgenerator->create_instance($params);
 
-        $this->quizobj = \quiz::create($this->quiz->id, $this->user1->id);
+        $this->quizobj = \mod_quiz\quiz_settings::create($this->quiz->id, $this->user1->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -166,7 +166,7 @@ class lib_test extends \advanced_testcase {
 
         \curl::mock_response(json_encode($testresponse));
 
-        $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        $attemptobj = \quiz_attempt::create($attempt->id);
         $attemptobj->process_finish(time(), false);
 
         $PAGE = new moodle_page();
@@ -240,7 +240,7 @@ class lib_test extends \advanced_testcase {
         $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
         $this->quiz = $quizgenerator->create_instance($params);
 
-        $this->quizobj = \mod_quiz\quiz_settings::create($this->quiz->id, $this->user1->id);
+        $this->quizobj = \quiz::create($this->quiz->id, $this->user1->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -136,7 +136,7 @@ class lib_test extends \advanced_testcase {
         $PAGE->set_cm($cm);
 
         $PAGE->set_url('/mod/quiz/startattempt.php',
-           array('cmid' => $cm->id, 'sesskey' => sesskey()));
+           ['cmid' => $cm->id, 'sesskey' => sesskey()]);
 
         $nav = new \global_navigation($PAGE);
 
@@ -175,7 +175,7 @@ class lib_test extends \advanced_testcase {
         $PAGE->set_cm($cm);
 
         $PAGE->set_url('/mod/quiz/startattempt.php',
-           array('cmid' => $cm->id, 'sesskey' => sesskey()));
+           ['cmid' => $cm->id, 'sesskey' => sesskey()]);
 
         $nav = new \global_navigation($PAGE);
 
@@ -201,7 +201,7 @@ class lib_test extends \advanced_testcase {
         $PAGE->set_cm($cm);
 
         $PAGE->set_url('/mod/quiz/summary.php',
-           array('cmid' => $cm->id, 'sesskey' => sesskey()));
+           ['cmid' => $cm->id, 'sesskey' => sesskey()]);
 
         $nav = new \global_navigation($PAGE);
 
@@ -245,7 +245,7 @@ class lib_test extends \advanced_testcase {
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 
         $cat = $questiongenerator->create_question_category();
-        $question = $questiongenerator->create_question('shortanswer', null, array('category' => $cat->id));
+        $question = $questiongenerator->create_question('shortanswer', null, ['category' => $cat->id]);
 
         quiz_add_quiz_question($question->id, $this->quiz);
     }

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -49,7 +49,7 @@ class observer_test extends \advanced_testcase {
     /**
      * @var user A generic user.
      */
-    protected $user;
+    protected $user1;
 
     /**
      * @var question_engine Question Engine.
@@ -250,7 +250,7 @@ class observer_test extends \advanced_testcase {
         $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
         $this->quiz = $quizgenerator->create_instance($params);
 
-        $this->quizobj = quiz::create($this->quiz->id, $this->user1->id);
+        $this->quizobj = \mod_quiz\quiz_settings::create($this->quiz->id, $this->user1->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 
@@ -290,7 +290,7 @@ class observer_test extends \advanced_testcase {
         );
 
         if ($completed) {
-            $this->attemptobj = \quiz_attempt::create($attempt->id);
+            $this->attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
             $this->attemptobj->process_finish(time(), false);
         }
 

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -95,7 +95,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_viewed
      */
-    public function test_quiz_viewed() {
+    public function test_quiz_viewed(): void {
         global $SESSION;
         $this->create_quiz();
         $SESSION->passwordcheckedquizzes[$this->quiz->id] = true;
@@ -114,7 +114,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_viewed
      */
-    public function test_quiz_viewed_does_not_unset_session_variable_if_not_honorlock_enabled() {
+    public function test_quiz_viewed_does_not_unset_session_variable_if_not_honorlock_enabled(): void {
         global $SESSION;
         $this->create_quiz(false);
         $SESSION->passwordcheckedquizzes[$this->quiz->id] = true;
@@ -131,7 +131,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_attempt_viewed
      */
-    public function test_quiz_attempt_viewed() {
+    public function test_quiz_attempt_viewed(): void {
         $this->create_quiz();
 
         $event = $this->create_attempt_view_event(false);
@@ -147,7 +147,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_attempt_viewed
      */
-    public function test_quiz_attempt_viewed_returns_early_when_not_honorlock_enabled() {
+    public function test_quiz_attempt_viewed_returns_early_when_not_honorlock_enabled(): void {
         $this->create_quiz(false);
         $event = $this->create_attempt_view_event($this->quiz);
 
@@ -163,7 +163,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_attempt_viewed
      */
-    public function test_quiz_attempt_viewed_returns_early_when_not_in_progress() {
+    public function test_quiz_attempt_viewed_returns_early_when_not_in_progress(): void {
         $this->create_quiz();
         $event = $this->create_attempt_view_event(true);
 
@@ -179,7 +179,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_attempt_submitted
      */
-    public function test_quiz_attempt_submitted() {
+    public function test_quiz_attempt_submitted(): void {
         $this->create_quiz();
         $this->create_attempt_view_event(true);
 
@@ -191,7 +191,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::quiz_attempt_submitted
      */
-    public function test_quiz_attempt_submitted_returns_early_when_honorlock_not_enabled() {
+    public function test_quiz_attempt_submitted_returns_early_when_honorlock_not_enabled(): void {
         $this->create_quiz(false);
         $this->create_attempt_view_event(true);
 
@@ -203,7 +203,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::is_honorlock_enabled_quiz
      */
-    public function test_is_honorlock_enabled_private_static_function() {
+    public function test_is_honorlock_enabled_private_static_function(): void {
         $this->create_quiz();
 
         $reflection = new \ReflectionClass(get_class($this->observer));
@@ -219,7 +219,7 @@ class observer_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\observer::get_honorlock_instance
      */
-    public function test_get_honorlock_instance_private_static_function() {
+    public function test_get_honorlock_instance_private_static_function(): void {
 
         $reflection = new \ReflectionClass(get_class($this->observer));
         $method = $reflection->getMethod('get_honorlock_instance');
@@ -236,7 +236,7 @@ class observer_test extends \advanced_testcase {
      * @param bool $honorlockenabled determine whether quiz will be Honorlock Enabled
      * @return void the generated event that has been triggered.
      */
-    private function create_quiz($honorlockenabled = true) : void {
+    private function create_quiz($honorlockenabled = true): void {
         $params = [
             'course' => $this->course->id,
             'questionsperpage' => 0,
@@ -255,7 +255,7 @@ class observer_test extends \advanced_testcase {
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 
         $cat = $questiongenerator->create_question_category();
-        $question = $questiongenerator->create_question('shortanswer', null, array('category' => $cat->id));
+        $question = $questiongenerator->create_question('shortanswer', null, ['category' => $cat->id]);
 
         quiz_add_quiz_question($question->id, $this->quiz);
 
@@ -269,7 +269,7 @@ class observer_test extends \advanced_testcase {
      * @param bool $completed determine whether the quiz will be completed
      * @return event the generated event that has been triggered.
      */
-    private function create_attempt_view_event($completed = false) {
+    private function create_attempt_view_event($completed = false): \mod_quiz\event\attempt_viewed {
 
         $this->setUser($this->user1);
 
@@ -278,16 +278,16 @@ class observer_test extends \advanced_testcase {
         quiz_start_new_attempt($this->quizobj, $this->quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($this->quizobj, $this->quba, $attempt);
 
-        $params = array(
+        $params = [
             'objectid' => $attempt->id,
             'relateduserid' => $this->user1->id,
             'courseid' => $this->course->id,
             'context' => \context_module::instance($this->quiz->cmid),
-            'other' => array(
+            'other' => [
                 'quizid' => $this->quiz->id,
                 'page' => 0
-            )
-        );
+            ]
+        ];
 
         if ($completed) {
             $this->attemptobj = \quiz_attempt::create($attempt->id);

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -250,7 +250,7 @@ class observer_test extends \advanced_testcase {
         $quizgenerator = $this->getDataGenerator()->get_plugin_generator('mod_quiz');
         $this->quiz = $quizgenerator->create_instance($params);
 
-        $this->quizobj = \mod_quiz\quiz_settings::create($this->quiz->id, $this->user1->id);
+        $this->quizobj = quiz::create($this->quiz->id, $this->user1->id);
 
         $questiongenerator = $this->getDataGenerator()->get_plugin_generator('core_question');
 
@@ -290,7 +290,7 @@ class observer_test extends \advanced_testcase {
         );
 
         if ($completed) {
-            $this->attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+            $this->attemptobj = \quiz_attempt::create($attempt->id);
             $this->attemptobj->process_finish(time(), false);
         }
 

--- a/tests/provider_test.php
+++ b/tests/provider_test.php
@@ -51,7 +51,7 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::get_metadata
      */
-    public function test_get_metadata() {
+    public function test_get_metadata(): void {
         $collection = new collection('local_honorlockproctoring');
         $this->provider->get_metadata($collection);
 
@@ -63,7 +63,7 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::get_contexts_for_userid
      */
-    public function test_get_contexts_for_userid() {
+    public function test_get_contexts_for_userid(): void {
         $user1 = $this->getDataGenerator()->create_user();
         $this->setUser($user1);
 
@@ -77,12 +77,12 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::export_user_data
      */
-    public function test_export_user_data() {
+    public function test_export_user_data(): void {
         $user1 = $this->getDataGenerator()->create_user();
         $this->setUser($user1);
 
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         $context = \context_module::instance($quiz->cmid);
 
@@ -97,9 +97,9 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::delete_data_for_all_users_in_context
      */
-    public function test_delete_data_for_all_users_in_context() {
+    public function test_delete_data_for_all_users_in_context(): void {
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         $context = \context_module::instance($quiz->cmid);
         $result = $this->provider->delete_data_for_all_users_in_context($context);
@@ -112,7 +112,7 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::delete_data_for_user
      */
-    public function test_delete_data_for_user() {
+    public function test_delete_data_for_user(): void {
         $user1 = $this->getDataGenerator()->create_user();
         $this->setUser($user1);
 
@@ -128,9 +128,9 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::get_users_in_context
      */
-    public function test_get_users_in_context() {
+    public function test_get_users_in_context(): void {
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         $context = \context_module::instance($quiz->cmid);
         $userlist = new userlist($context, 'local_honorlockproctoring');
@@ -145,12 +145,12 @@ class provider_test extends \advanced_testcase {
      *
      * @covers \local_honorlockproctoring\privacy\provider::delete_data_for_users
      */
-    public function test_delete_data_for_users() {
+    public function test_delete_data_for_users(): void {
         $user1 = $this->getDataGenerator()->create_user();
         $this->setUser($user1);
 
         $course = $this->getDataGenerator()->create_course();
-        $quiz = $this->getDataGenerator()->create_module('quiz', array('course' => $course->id));
+        $quiz = $this->getDataGenerator()->create_module('quiz', ['course' => $course->id]);
 
         $context = \context_module::instance($quiz->cmid);
         $userlist = new approved_userlist($context, 'local_honorlockproctoring', [$user1->id]);

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_honorlockproctoring';
-$plugin->release = '1.0.3';
-$plugin->version = 2023112801;
+$plugin->release = '1.0.4';
+$plugin->version = 2023120501;
 $plugin->requires = 2020061500;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Includes tickets: 

https://honorlock.atlassian.net/browse/HL-18283 - Update the Readme
https://honorlock.atlassian.net/browse/HL-18284 - Update the coding styles
https://honorlock.atlassian.net/browse/HL-18286 - Add new versions to Github actions


Testing Notes:

To test it, we will need to download the Plugin from the branch: taskkwHL-18283_update_readme_to_indicate_commercial_subscription_is_required and install it as an Admin in Moodle. See the testing the Moodle Plugin guide for more detailed steps: https://honorlock.atlassian.net/wiki/spaces/eng/pages/1118470240/Testing+the+Moodle+Plugin

For ticket [HL-18283](https://honorlock.atlassian.net/browse/HL-18283)
We need to verify that the Readme now indicates that a commercial license is required

For ticket [HL-18284](https://honorlock.atlassian.net/browse/HL-18284)
There was no functionality changes, just styling changes requested by Moodle. A simple smoke test to make sure a student can still take a test and a teacher can still access the LTI should suffice. 

For ticket [HL-18286](https://honorlock.atlassian.net/browse/HL-18286)
We need to verify that we added Moodle versions to the Github check below. You should see a check was run for Moodle 401 running php 8.1, Moodle 400 running php 7.4, Moodle 310 running php 7.3 and Moodle 39 running php 7.3

<img width="853" alt="Screen Shot 2023-12-05 at 2 41 38 PM" src="https://github.com/HonorLock/moodle-plugin/assets/107198570/66928397-426c-4cdc-b48e-e410be42dd7d">

[HL-18283]: https://honorlock.atlassian.net/browse/HL-18283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-18284]: https://honorlock.atlassian.net/browse/HL-18284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HL-18286]: https://honorlock.atlassian.net/browse/HL-18286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ