### PR TITLE
🌵 HL-30092 Bump shivammathur/setup-php to 2.37.1 in CI workflow.

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -57,7 +57,7 @@ jobs:
           path: plugin
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@v2.37.1
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -57,7 +57,7 @@ jobs:
           path: plugin
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2.37.1
+        uses: shivammathur/setup-php@2.37.1
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}


### PR DESCRIPTION
🎫 [HL-30092](https://honorlock.atlassian.net/browse/HL-30092)
ℹ️ Pin setup-php to the patched version 2.37.1 to clear the open Dependabot alert flagging potential GitHub token exposure in build logs. Our workflow does not pin Composer via `tools:`, so the vulnerable code path is not exercised, but pinning to the patched release keeps us current and resolves the alert.
CI-only change — no plugin runtime, data-handling, or customer-facing impact. Matches the existing tag-pinning convention (e.g. actions/checkout@v3).

[HL-30092]: https://honorlock.atlassian.net/browse/HL-30092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ